### PR TITLE
возможность передавать cloud-init скрипт при создании сервера

### DIFF
--- a/twc/api/client.py
+++ b/twc/api/client.py
@@ -118,6 +118,7 @@ class TimewebCloud(TimewebCloudBase):
         availability_zone: Optional[ServiceAvailabilityZone] = None,
         is_root_password_required: Optional[bool] = None,
         project_id: Optional[int] = None,
+        cloud_init: Optional[str] = None,
     ):
         """Create new Cloud Server. Note:
 
@@ -161,6 +162,7 @@ class TimewebCloud(TimewebCloudBase):
                 else {}
             ),
             **({"project_id": project_id} if project_id else {}),
+            **({"cloud_init": cloud_init} if cloud_init else {}),
         }
 
         return self._request("POST", f"{self.api_url}/servers", json=payload)


### PR DESCRIPTION
<img width="1955" height="773" alt="image" src="https://github.com/user-attachments/assets/056b2048-d056-49da-965c-4662fb526141" />
решает следующую ошибку при создании сервера